### PR TITLE
Fix FaceMesh cleanup in hook

### DIFF
--- a/src/hooks/useMediaPipeFaceDetection.ts
+++ b/src/hooks/useMediaPipeFaceDetection.ts
@@ -262,6 +262,10 @@ export const useMediaPipeFaceDetection = (
   useEffect(() => {
     const initializeMediaPipe = async () => {
       try {
+        if (faceMeshRef.current) {
+          faceMeshRef.current.close?.();
+        }
+
         const faceMesh = new FaceMesh({
           locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/face_mesh/${file}`
         });
@@ -313,6 +317,11 @@ export const useMediaPipeFaceDetection = (
     return () => {
       if (cameraRef.current) {
         cameraRef.current.stop();
+        cameraRef.current = null;
+      }
+      if (faceMeshRef.current) {
+        faceMeshRef.current.close?.();
+        faceMeshRef.current = null;
       }
     };
   }, [onResults, videoRef, canvasRef]);


### PR DESCRIPTION
## Summary
- close FaceMesh instance on cleanup
- ensure existing FaceMesh instance is closed before creating a new one

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*