### PR TITLE
Add gesture conflict detection

### DIFF
--- a/src/components/WebcamFeed.tsx
+++ b/src/components/WebcamFeed.tsx
@@ -5,6 +5,7 @@ import { useMediaPipeFaceDetection } from '@/hooks/useMediaPipeFaceDetection';
 interface WebcamFeedProps {
   onGestureDetected: (gesture: 'yes' | 'no') => void;
   onFaceData: (faces: any[], fps: number) => void;
+  onConflictPair?: (pair: { yes: any; no: any }) => void;
   fallbackMode: boolean;
   debugMode?: boolean;
   showOutlines?: boolean;
@@ -19,6 +20,7 @@ interface HeadPose {
 const WebcamFeed: React.FC<WebcamFeedProps> = ({
   onGestureDetected,
   onFaceData,
+  onConflictPair,
   fallbackMode,
   debugMode = false,
   showOutlines = true
@@ -29,11 +31,19 @@ const WebcamFeed: React.FC<WebcamFeedProps> = ({
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [headPoseData, setHeadPoseData] = useState<HeadPose | null>(null);
 
+  const handleConflictFromHook = React.useCallback(
+    (pair: { yes: any; no: any }) => {
+      onConflictPair?.(pair);
+    },
+    [onConflictPair]
+  );
+
   // Use our MediaPipe detection hook (enabled = !fallbackMode)
   const { faces, fps, isLoading, error, isPreparing } = useMediaPipeFaceDetection(
     videoRef,
     canvasRef,
     onGestureDetected,
+    handleConflictFromHook,
     !fallbackMode,
     showOutlines
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -96,6 +96,12 @@ const Index = () => {
     setFps(currentFps);
   }, []);
 
+  const handleConflictPair = useCallback(() => {
+    if (!isDiscussionOpen) {
+      setIsDiscussionOpen(true);
+    }
+  }, [isDiscussionOpen]);
+
   // -----------------------------------------
   // Clear / Export data
   // -----------------------------------------
@@ -173,6 +179,7 @@ const Index = () => {
               <WebcamFeed
                 onGestureDetected={handleGestureDetected}
                 onFaceData={handleFaceData}
+                onConflictPair={handleConflictPair}
                 fallbackMode={fallbackMode}
                 debugMode={debugMode}
               />


### PR DESCRIPTION
## Summary
- track per-face gesture history in `useMediaPipeFaceDetection`
- draw connecting lines when one face nods "yes" and another shakes "no"
- expose `onConflictPair` callback through `WebcamFeed`
- automatically open the chat when a gesture conflict occurs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`