### PR TITLE
Add persistent face voting logic

### DIFF
--- a/src/components/WebcamFeed.tsx
+++ b/src/components/WebcamFeed.tsx
@@ -3,7 +3,7 @@ import { Card } from '@/components/ui/card';
 import { useMediaPipeFaceDetection } from '@/hooks/useMediaPipeFaceDetection';
 
 interface WebcamFeedProps {
-  onGestureDetected: (gesture: 'yes' | 'no') => void;
+  onGestureDetected: (gesture: 'yes' | 'no', faceId: number) => void;
   onFaceData: (faces: any[], fps: number) => void;
   onConflictPair?: (pair: { yes: any; no: any }) => void;
   fallbackMode: boolean;

--- a/src/hooks/useMediaPipeFaceDetection.ts
+++ b/src/hooks/useMediaPipeFaceDetection.ts
@@ -36,7 +36,7 @@ interface FaceDetectionResult {
 export const useMediaPipeFaceDetection = (
   videoRef: React.RefObject<HTMLVideoElement>,
   canvasRef: React.RefObject<HTMLCanvasElement>,
-  onGestureDetected: (gesture: 'yes' | 'no') => void,
+  onGestureDetected: (gesture: 'yes' | 'no', faceId: number) => void,
   onConflictPair?: (pair: { yes: FaceData; no: FaceData }) => void,
   enabled: boolean = true,
   drawFaceBoxes: boolean = true
@@ -163,14 +163,14 @@ export const useMediaPipeFaceDetection = (
           avgConfidence > GESTURE_CONFIDENCE_THRESHOLD
         ) {
           if (yesCount >= Math.ceil(REQUIRED_GESTURE_FRAMES * 0.9)) {
-            onGestureDetected('yes');
+            onGestureDetected('yes', faceId);
             lastGestureTimeMapRef.current[faceId] = now;
             lastGesturePerFaceRef.current[faceId] = 'yes';
             gestureHistoryMapRef.current[faceId] = [];
             preparingRef.current = false;
             setResult(prev => ({ ...prev, isPreparing: false }));
           } else if (noCount >= Math.ceil(REQUIRED_GESTURE_FRAMES * 0.9)) {
-            onGestureDetected('no');
+            onGestureDetected('no', faceId);
             lastGestureTimeMapRef.current[faceId] = now;
             lastGesturePerFaceRef.current[faceId] = 'no';
             gestureHistoryMapRef.current[faceId] = [];
@@ -239,8 +239,9 @@ export const useMediaPipeFaceDetection = (
               ? 1 - timeSinceGesture / GESTURE_COOLDOWN_MS
               : 1;
             let color = '128,128,128';
-            if (gestureResult?.gesture === 'yes') color = '0,255,0';
-            else if (gestureResult?.gesture === 'no') color = '255,0,0';
+            const persistentGesture = lastGesturePerFaceRef.current[index];
+            if (persistentGesture === 'yes') color = '0,255,0';
+            else if (persistentGesture === 'no') color = '255,0,0';
 
             ctx.save();
             ctx.lineWidth = 3;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -28,6 +28,7 @@ const Index = () => {
   const [fps, setFps] = useState(30);
   const [detectedFaces, setDetectedFaces] = useState([]);
   const [sessionStats, setSessionStats] = useState(dataService.getSessionStats());
+  const faceVotesRef = useRef<Record<number, Set<number>>>({});
 
   // On mount, load session data
   useEffect(() => {
@@ -62,7 +63,15 @@ const Index = () => {
   // -----------------------------------------
   // 1) Memoized Callback: handleGestureDetected
   // -----------------------------------------
-  const handleGestureDetected = useCallback((gesture: 'yes' | 'no') => {
+  const handleGestureDetected = useCallback((gesture: 'yes' | 'no', faceId: number) => {
+    if (!faceVotesRef.current[currentQuestion]) {
+      faceVotesRef.current[currentQuestion] = new Set();
+    }
+    if (faceVotesRef.current[currentQuestion].has(faceId)) {
+      return;
+    }
+    faceVotesRef.current[currentQuestion].add(faceId);
+
     // Add vote to persistence
     const newVotes = dataService.addVote(currentQuestion, gesture);
     setVotes(newVotes);
@@ -193,14 +202,14 @@ const Index = () => {
               {/* Dev Controls */}
               <div className="mt-4 flex gap-2 justify-center flex-wrap">
                 <Button
-                  onClick={() => handleGestureDetected('yes')}
+                  onClick={() => handleGestureDetected('yes', -1)}
                   className="bg-green-600 hover:bg-green-700"
                   size="sm"
                 >
                   Test YES
                 </Button>
                 <Button
-                  onClick={() => handleGestureDetected('no')}
+                  onClick={() => handleGestureDetected('no', -1)}
                   className="bg-red-600 hover:bg-red-700"
                   size="sm"
                 >


### PR DESCRIPTION
## Summary
- color face boxes by last recorded gesture
- avoid duplicate votes by tracking face IDs
- wire gesture callbacks with face identifiers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d45d9b858832092bd5947ce6d6209