### PR TITLE
Fix overlay reset when question changes

### DIFF
--- a/src/components/WebcamFeed.tsx
+++ b/src/components/WebcamFeed.tsx
@@ -9,6 +9,8 @@ interface WebcamFeedProps {
   fallbackMode: boolean;
   debugMode?: boolean;
   showOutlines?: boolean;
+  /** Current question index used to reset overlays */
+  questionId: number;
 }
 
 interface HeadPose {
@@ -23,7 +25,8 @@ const WebcamFeed: React.FC<WebcamFeedProps> = ({
   onConflictPair,
   fallbackMode,
   debugMode = false,
-  showOutlines = true
+  showOutlines = true,
+  questionId
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -45,7 +48,8 @@ const WebcamFeed: React.FC<WebcamFeedProps> = ({
     onGestureDetected,
     handleConflictFromHook,
     !fallbackMode,
-    showOutlines
+    showOutlines,
+    questionId
   );
 
   // Clear camera error when we exit fallback

--- a/src/hooks/useMediaPipeFaceDetection.ts
+++ b/src/hooks/useMediaPipeFaceDetection.ts
@@ -39,7 +39,8 @@ export const useMediaPipeFaceDetection = (
   onGestureDetected: (gesture: 'yes' | 'no', faceId: number) => void,
   onConflictPair?: (pair: { yes: FaceData; no: FaceData }) => void,
   enabled: boolean = true,
-  drawFaceBoxes: boolean = true
+  drawFaceBoxes: boolean = true,
+  resetTrigger?: number
 ): FaceDetectionResult => {
   const [result, setResult] = useState<FaceDetectionResult>({
     faces: [],
@@ -74,6 +75,13 @@ export const useMediaPipeFaceDetection = (
   const GESTURE_CONFIDENCE_THRESHOLD = 0.7;
   const NOD_THRESHOLD = 0.05;
   const SHAKE_THRESHOLD = 0.06;
+
+  // Reset gesture overlays when the resetTrigger changes
+  useEffect(() => {
+    lastGesturePerFaceRef.current = {};
+    lastGestureTimeMapRef.current = {};
+    gestureHistoryMapRef.current = {};
+  }, [resetTrigger]);
 
   // -------------------------------
   // 1) computeFaceRect Helper

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -206,6 +206,7 @@ const Index = () => {
                 onConflictPair={handleConflictPair}
                 fallbackMode={fallbackMode}
                 debugMode={debugMode}
+                questionId={currentQuestion}
               />
 
               {/* Dev Controls */}


### PR DESCRIPTION
## Summary
- allow WebcamFeed to accept current question id
- pass question id from Index to WebcamFeed
- reset gesture overlays in face detection hook when question changes

## Testing
- `npx tsc --noEmit` *(fails: Unknown env config, no output)*

------
https://chatgpt.com/codex/tasks/task_e_685a1c1e12f08320b7cbe3cb6e41f212