### PR TITLE
Reset face overlay color when question changes

### DIFF
--- a/src/components/WebcamFeed.tsx
+++ b/src/components/WebcamFeed.tsx
@@ -9,6 +9,8 @@ interface WebcamFeedProps {
   fallbackMode: boolean;
   debugMode?: boolean;
   showOutlines?: boolean;
+  /** Current question index used to reset overlay colors */
+  questionId: number;
 }
 
 interface HeadPose {
@@ -23,7 +25,8 @@ const WebcamFeed: React.FC<WebcamFeedProps> = ({
   onConflictPair,
   fallbackMode,
   debugMode = false,
-  showOutlines = true
+  showOutlines = true,
+  questionId
 }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -45,7 +48,8 @@ const WebcamFeed: React.FC<WebcamFeedProps> = ({
     onGestureDetected,
     handleConflictFromHook,
     !fallbackMode,
-    showOutlines
+    showOutlines,
+    questionId
   );
 
   // Clear camera error when we exit fallback

--- a/src/hooks/useMediaPipeFaceDetection.ts
+++ b/src/hooks/useMediaPipeFaceDetection.ts
@@ -39,7 +39,8 @@ export const useMediaPipeFaceDetection = (
   onGestureDetected: (gesture: 'yes' | 'no', faceId: number) => void,
   onConflictPair?: (pair: { yes: FaceData; no: FaceData }) => void,
   enabled: boolean = true,
-  drawFaceBoxes: boolean = true
+  drawFaceBoxes: boolean = true,
+  questionId?: number
 ): FaceDetectionResult => {
   const [result, setResult] = useState<FaceDetectionResult>({
     faces: [],
@@ -67,6 +68,16 @@ export const useMediaPipeFaceDetection = (
   const lastGesturePerFaceRef = useRef<Record<number, 'yes' | 'no' | null>>({});
   const preparingRef = useRef(false);
   const lastConflictTimeRef = useRef(0);
+
+  // Reset gesture history when question changes
+  useEffect(() => {
+    previousNosePositionRef.current = {};
+    gestureHistoryMapRef.current = {};
+    lastGestureTimeMapRef.current = {};
+    lastGesturePerFaceRef.current = {};
+    preparingRef.current = false;
+    lastConflictTimeRef.current = 0;
+  }, [questionId]);
 
   // Constants
   const REQUIRED_GESTURE_FRAMES = 6;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -206,6 +206,7 @@ const Index = () => {
                 onConflictPair={handleConflictPair}
                 fallbackMode={fallbackMode}
                 debugMode={debugMode}
+                questionId={currentQuestion}
               />
 
               {/* Dev Controls */}


### PR DESCRIPTION
## Summary
- pass `questionId` to `WebcamFeed`
- add `questionId` parameter to `useMediaPipeFaceDetection`
- clear internal gesture state when a new question arrives

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685a1dbe9fa4832092c189201a52d34d