### PR TITLE
Add dynamic question timer

### DIFF
--- a/src/components/QuestionDisplay.tsx
+++ b/src/components/QuestionDisplay.tsx
@@ -6,12 +6,16 @@ interface QuestionDisplayProps {
   question: string;
   questionIndex: number;
   totalQuestions: number;
+  timeRemaining: number;
+  questionDuration: number;
 }
 
 const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
   question,
   questionIndex,
   totalQuestions,
+  timeRemaining,
+  questionDuration,
 }) => {
   return (
     <Card className="bg-black/60 border-gray-700 p-8 shadow-lg">
@@ -34,11 +38,17 @@ const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
       </div>
 
       <div className="flex justify-between items-center text-sm text-gray-400">
-        <span>Next question in 45s</span>
+        <span>Next question in {timeRemaining}s</span>
         <div className="flex gap-2 items-center">
           <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
           <span>Live</span>
         </div>
+      </div>
+      <div className="mt-2 w-full bg-gray-700 rounded-full h-1">
+        <div
+          className="bg-gradient-to-r from-green-500 to-blue-500 h-1 rounded-full transition-all duration-1000"
+          style={{ width: `${((questionDuration - timeRemaining) / questionDuration) * 100}%` }}
+        ></div>
       </div>
 
       <div className="mt-4 w-full bg-gray-700 rounded-full h-1">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,6 +21,8 @@ const SECURITY_QUESTIONS = [
   "Would you share your login credentials with a close friend?"
 ];
 
+const QUESTION_DURATION_MS = 45000;
+
 const Index = () => {
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const [votes, setVotes] = useState({ yes: 0, no: 0 });
@@ -29,6 +31,7 @@ const Index = () => {
   const [debugMode, setDebugMode] = useState(false);
   const [fps, setFps] = useState(30);
   const [detectedFaces, setDetectedFaces] = useState([]);
+  const [timeRemaining, setTimeRemaining] = useState(QUESTION_DURATION_MS / 1000);
   const [sessionStats, setSessionStats] = useState(dataService.getSessionStats());
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   const faceVotesRef = useRef<Record<number, Set<number>>>({});
@@ -43,7 +46,7 @@ const Index = () => {
     setVotes(savedVotes);
   }, []);
 
-  // Rotate questions every 15s
+  // Rotate questions every 45s
   useEffect(() => {
     const interval = setInterval(() => {
       const nextQuestion = (currentQuestion + 1) % SECURITY_QUESTIONS.length;
@@ -57,6 +60,19 @@ const Index = () => {
     }, 45000);
 
     return () => clearInterval(interval);
+  }, [currentQuestion]);
+
+  // Countdown timer for current question
+  useEffect(() => {
+    const start = Date.now();
+    const tick = () => {
+      const elapsed = Date.now() - start;
+      const remaining = Math.max(0, QUESTION_DURATION_MS - elapsed);
+      setTimeRemaining(Math.ceil(remaining / 1000));
+    };
+    tick();
+    const t = setInterval(tick, 1000);
+    return () => clearInterval(t);
   }, [currentQuestion]);
 
   // Avoid toggling fallback mode too quickly around ~15–20 FPS
@@ -182,6 +198,8 @@ const Index = () => {
           question={SECURITY_QUESTIONS[currentQuestion]}
           questionIndex={currentQuestion + 1}
           totalQuestions={SECURITY_QUESTIONS.length}
+          timeRemaining={timeRemaining}
+          questionDuration={QUESTION_DURATION_MS / 1000}
         />
 
         <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- implement countdown timer in `QuestionDisplay`
- track timer state in `Index` page
- pass timer props to question display
- fix comment about question interval

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_685a28114a1083208efa0ec41d436732