### PR TITLE
Add statistics view

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Nod & Know is an interactive security awareness demo. It uses your webcam to det
    npm run dev
    ```
    The app runs on <http://localhost:8080> by default.
+   You can view aggregated session statistics at <http://localhost:8080/stats> while the server is running.
 3. Build for production:
    ```sh
    npm run build
@@ -27,6 +28,7 @@ Nod & Know is an interactive security awareness demo. It uses your webcam to det
 - **src/components/ChatInterface.tsx** – modal chat window driven by a mocked WebSocket service.
 - **src/services/dataService.ts** – stores session data and lightweight analytics in `localStorage`.
 - **src/services/websocketService.ts** – simulates a chat server for anonymous discussion.
+- **src/pages/Stats.tsx** – visualizes anonymous event logs and vote data.
 
 Everything runs entirely in the browser, so no data is sent to a backend.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Stats from "./pages/Stats";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/stats" element={<Stats />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,6 +8,7 @@ import ChatInterface from '@/components/ChatInterface';
 import QuestionDisplay from '@/components/QuestionDisplay';
 import { dataService } from '@/services/dataService';
 import HelpDialog from '@/components/HelpDialog';
+import { Link } from 'react-router-dom';
 import { toast } from '@/components/ui/sonner';
 
 const SECURITY_QUESTIONS = [
@@ -187,10 +188,13 @@ const Index = () => {
             </Badge>
           )}
         </div>
-        <div className="mt-4">
+        <div className="mt-4 flex gap-2 justify-center">
           <Button variant="outline" size="sm" onClick={() => setIsHelpOpen(true)}>
             Help
           </Button>
+          <Link to="/stats">
+            <Button variant="outline" size="sm">Stats</Button>
+          </Link>
         </div>
       </div>
 

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo } from 'react';
+import { dataService } from '@/services/dataService';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Link } from 'react-router-dom';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts';
+
+const Stats = () => {
+  const session = dataService.getSessionData();
+  const events = dataService.getAnalyticsEvents();
+
+  const voteData = useMemo(() => {
+    return Object.values(session.votes).map((v: any) => ({
+      question: `Q${v.questionId + 1}`,
+      yes: v.yes,
+      no: v.no,
+    }));
+  }, [session.votes]);
+
+  const gestureCounts = useMemo(() => {
+    let yes = 0;
+    let no = 0;
+    events.forEach((e: any) => {
+      if (e.type === 'gesture_detected') {
+        if (e.data.gesture === 'yes') yes++;
+        if (e.data.gesture === 'no') no++;
+      }
+    });
+    return { yes, no };
+  }, [events]);
+
+  const gestureData = [
+    { gesture: 'Yes', count: gestureCounts.yes },
+    { gesture: 'No', count: gestureCounts.no },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-4 text-white">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex justify-between items-center">
+          <h1 className="text-3xl font-semibold">Session Statistics</h1>
+          <Link to="/">
+            <Button variant="outline" size="sm">Back</Button>
+          </Link>
+        </div>
+
+        <Card className="bg-black/50 border-gray-700 p-6">
+          <h2 className="text-xl font-semibold mb-4">Vote Trends</h2>
+          <div className="w-full h-64">
+            <ResponsiveContainer>
+              <BarChart data={voteData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#555" />
+                <XAxis dataKey="question" stroke="#ddd" />
+                <YAxis allowDecimals={false} stroke="#ddd" />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="yes" fill="#22c55e" name="Yes" />
+                <Bar dataKey="no" fill="#ef4444" name="No" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
+
+        <Card className="bg-black/50 border-gray-700 p-6">
+          <h2 className="text-xl font-semibold mb-4">Gesture Frequency</h2>
+          <div className="w-full h-64">
+            <ResponsiveContainer>
+              <BarChart data={gestureData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#555" />
+                <XAxis dataKey="gesture" stroke="#ddd" />
+                <YAxis allowDecimals={false} stroke="#ddd" />
+                <Tooltip />
+                <Bar dataKey="count" fill="#3b82f6" name="Count" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Stats;


### PR DESCRIPTION
## Summary
- show aggregated session statistics at `/stats`
- link to new view from the home page
- document the statistics feature in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2b7b6a5083208567b5276262fbb3