### PR TITLE
Implement question answers and match cooldown

### DIFF
--- a/src/components/QuestionDisplay.tsx
+++ b/src/components/QuestionDisplay.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 
 interface QuestionDisplayProps {
   question: string;
+  answer: string;
   questionIndex: number;
   totalQuestions: number;
   timeRemaining: number;
@@ -12,6 +13,7 @@ interface QuestionDisplayProps {
 
 const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
   question,
+  answer,
   questionIndex,
   totalQuestions,
   timeRemaining,
@@ -35,6 +37,7 @@ const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
         <p className="text-gray-200 text-xl leading-relaxed text-center">
           {question}
         </p>
+        <p className="text-sm text-gray-400 mt-2 text-center">Recommended answer: {answer}</p>
       </div>
 
       <div className="flex justify-between items-center text-sm text-gray-400">

--- a/src/hooks/useMediaPipeFaceDetection.ts
+++ b/src/hooks/useMediaPipeFaceDetection.ts
@@ -82,6 +82,7 @@ export const useMediaPipeFaceDetection = (
   // Constants
   const REQUIRED_GESTURE_FRAMES = 6;
   const GESTURE_COOLDOWN_MS = 4000;
+  const CONFLICT_COOLDOWN_MS = 30000;
   const GESTURE_CONFIDENCE_THRESHOLD = 0.7;
   const NOD_THRESHOLD = 0.05;
   const SHAKE_THRESHOLD = 0.06;
@@ -305,7 +306,7 @@ export const useMediaPipeFaceDetection = (
 
           if (onConflictPair) {
             const nowTime = performance.now();
-            if (nowTime - lastConflictTimeRef.current > GESTURE_COOLDOWN_MS) {
+            if (nowTime - lastConflictTimeRef.current > CONFLICT_COOLDOWN_MS) {
               lastConflictTimeRef.current = nowTime;
               onConflictPair({ yes: yesFaces[0], no: noFaces[0] });
             }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,14 +12,38 @@ import { Link } from 'react-router-dom';
 import { toast } from '@/components/ui/sonner';
 
 const SECURITY_QUESTIONS = [
-  "Do you reuse the same password across multiple accounts?",
-  "Have you enabled two-factor authentication on your main email?",
-  "Do you use your fingerprint to unlock your phone?",
-  "Would you click a link in an unexpected email from your bank?",
-  "Do you regularly update your software when prompted?",
-  "Would you connect to free public WiFi for online banking?",
-  "Do you backup your important files regularly?",
-  "Would you share your login credentials with a close friend?"
+  {
+    question: "Do you reuse the same password across multiple accounts?",
+    answer: "No",
+  },
+  {
+    question: "Have you enabled two-factor authentication on your main email?",
+    answer: "Yes",
+  },
+  {
+    question: "Do you use your fingerprint to unlock your phone?",
+    answer: "Yes",
+  },
+  {
+    question: "Would you click a link in an unexpected email from your bank?",
+    answer: "No",
+  },
+  {
+    question: "Do you regularly update your software when prompted?",
+    answer: "Yes",
+  },
+  {
+    question: "Would you connect to free public WiFi for online banking?",
+    answer: "No",
+  },
+  {
+    question: "Do you backup your important files regularly?",
+    answer: "Yes",
+  },
+  {
+    question: "Would you share your login credentials with a close friend?",
+    answer: "No",
+  },
 ];
 
 const QUESTION_DURATION_MS = 45000;
@@ -125,12 +149,15 @@ const Index = () => {
     setFps(currentFps);
   }, []);
 
-  const handleConflictPair = useCallback(() => {
-    toast('Matched with an opposite viewpoint! Join the discussion.');
-    if (!isDiscussionOpen) {
-      setIsDiscussionOpen(true);
-    }
-  }, [isDiscussionOpen]);
+  const handleConflictPair = useCallback(
+    (pair: { yes: any; no: any }) => {
+      toast(`Face ${pair.yes.id} and Face ${pair.no.id} matched`);
+      if (!isDiscussionOpen) {
+        setIsDiscussionOpen(true);
+      }
+    },
+    [isDiscussionOpen]
+  );
 
   // -----------------------------------------
   // Clear / Export data
@@ -199,7 +226,8 @@ const Index = () => {
       </div>
 
         <QuestionDisplay
-          question={SECURITY_QUESTIONS[currentQuestion]}
+          question={SECURITY_QUESTIONS[currentQuestion].question}
+          answer={SECURITY_QUESTIONS[currentQuestion].answer}
           questionIndex={currentQuestion + 1}
           totalQuestions={SECURITY_QUESTIONS.length}
           timeRemaining={timeRemaining}
@@ -325,7 +353,7 @@ const Index = () => {
         {/* Chat Interface Modal */}
         {isDiscussionOpen && (
           <ChatInterface
-            question={SECURITY_QUESTIONS[currentQuestion]}
+            question={SECURITY_QUESTIONS[currentQuestion].question}
             onClose={() => setIsDiscussionOpen(false)}
           />
         )}


### PR DESCRIPTION
## Summary
- define answers for security questions
- display each question's recommended answer
- show matched face IDs when users disagree
- limit conflict notifications using a 30s cooldown

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa927cbcc8320a1e90670114c0b1d