### PR TITLE
Implement question cooldown overlay

### DIFF
--- a/src/components/AnswerOverlay.tsx
+++ b/src/components/AnswerOverlay.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import QRCode from 'qrcode';
+
+interface AnswerOverlayProps {
+  open: boolean;
+  recommendedAnswer: string;
+  timeRemaining: number;
+  duration: number;
+}
+
+const AnswerOverlay: React.FC<AnswerOverlayProps> = ({ open, recommendedAnswer, timeRemaining, duration }) => {
+  const [qr, setQr] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      QRCode.toDataURL(window.location.href).then(setQr).catch(() => {});
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const progress = (duration - timeRemaining) / duration;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4">
+      <Card className="bg-gray-900 border-gray-700 text-gray-100 p-6 text-center space-y-4">
+        <h3 className="text-2xl font-semibold">Recommended Answer</h3>
+        <p className="text-xl">{recommendedAnswer}</p>
+        {qr && <img src={qr} alt="QR code" className="mx-auto w-40 h-40" />}
+        <div className="w-full bg-gray-700 rounded-full h-2">
+          <div
+            className="bg-gradient-to-r from-green-500 to-blue-500 h-2 rounded-full transition-all duration-1000"
+            style={{ width: `${progress * 100}%` }}
+          ></div>
+        </div>
+        <p className="text-sm text-gray-300">Next question in {timeRemaining}s</p>
+      </Card>
+    </div>
+  );
+};
+
+export default AnswerOverlay;

--- a/src/hooks/useMediaPipeFaceDetection.ts
+++ b/src/hooks/useMediaPipeFaceDetection.ts
@@ -99,7 +99,8 @@ export const useMediaPipeFaceDetection = (
   const REQUIRED_GESTURE_FRAMES = 6;
   const GESTURE_COOLDOWN_MS = 4000;
   const GESTURE_CONFIDENCE_THRESHOLD = 0.7;
-  const NOD_THRESHOLD = 0.05;
+  // Lower nod threshold slightly so "yes" gestures register more reliably
+  const NOD_THRESHOLD = 0.03;
   const SHAKE_THRESHOLD = 0.06;
 
   // -------------------------------


### PR DESCRIPTION
## Summary
- add a cooldown overlay that presents the recommended answer
- show a QR code during the cooldown
- ignore gestures while cooling down
- display question only during the active phase
- tune nod detection threshold so yes votes register better

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_685dff8169b48320a56ebff247b8ee15