### PR TITLE
Add cooldown phase and improve nod detection

### DIFF
--- a/src/components/CooldownDisplay.tsx
+++ b/src/components/CooldownDisplay.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+interface CooldownDisplayProps {
+  recommended: 'yes' | 'no';
+  remaining: number;
+}
+
+const CooldownDisplay: React.FC<CooldownDisplayProps> = ({ recommended, remaining }) => {
+  return (
+    <Card className="bg-black/60 border-gray-700 p-8 text-center shadow-lg">
+      <h3 className="text-xl font-semibold text-white mb-4">Hold on...</h3>
+      <p className="text-gray-200 text-lg mb-4">
+        Recommended answer: <span className={recommended === 'yes' ? 'text-green-400' : 'text-red-400'}>{recommended.toUpperCase()}</span>
+      </p>
+      <p className="text-gray-400 text-sm">Next question in {remaining}s</p>
+      <div className="mt-4 w-full bg-gray-700 rounded-full h-1">
+        <div
+          className="bg-gradient-to-r from-purple-500 to-blue-500 h-1 rounded-full transition-all duration-1000"
+          style={{ width: `${((20 - remaining) / 20) * 100}%` }}
+        ></div>
+      </div>
+      <div className="mt-4">
+        <Badge variant="outline" className="text-yellow-400 border-yellow-400">
+          Cooldown
+        </Badge>
+      </div>
+    </Card>
+  );
+};
+
+export default CooldownDisplay;

--- a/src/hooks/useMediaPipeFaceDetection.ts
+++ b/src/hooks/useMediaPipeFaceDetection.ts
@@ -99,7 +99,7 @@ export const useMediaPipeFaceDetection = (
   const REQUIRED_GESTURE_FRAMES = 6;
   const GESTURE_COOLDOWN_MS = 4000;
   const GESTURE_CONFIDENCE_THRESHOLD = 0.7;
-  const NOD_THRESHOLD = 0.05;
+  const NOD_THRESHOLD = 0.04;
   const SHAKE_THRESHOLD = 0.06;
 
   // -------------------------------
@@ -236,14 +236,14 @@ export const useMediaPipeFaceDetection = (
           now - lastTime > GESTURE_COOLDOWN_MS &&
           avgConfidence > GESTURE_CONFIDENCE_THRESHOLD
         ) {
-          if (yesCount >= Math.ceil(REQUIRED_GESTURE_FRAMES * 0.9)) {
+          if (yesCount >= Math.ceil(REQUIRED_GESTURE_FRAMES * 0.8)) {
             onGestureDetected('yes', faceId);
             lastGestureTimeMapRef.current[faceId] = now;
             lastGesturePerFaceRef.current[faceId] = 'yes';
             gestureHistoryMapRef.current[faceId] = [];
             preparingRef.current = false;
             setResult(prev => ({ ...prev, isPreparing: false }));
-          } else if (noCount >= Math.ceil(REQUIRED_GESTURE_FRAMES * 0.9)) {
+          } else if (noCount >= Math.ceil(REQUIRED_GESTURE_FRAMES * 0.8)) {
             onGestureDetected('no', faceId);
             lastGestureTimeMapRef.current[faceId] = now;
             lastGesturePerFaceRef.current[faceId] = 'no';

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import WebcamFeed from '@/components/WebcamFeed';
 import VoteChart from '@/components/VoteChart';
 import ChatInterface from '@/components/ChatInterface';
 import QuestionDisplay from '@/components/QuestionDisplay';
+import CooldownDisplay from '@/components/CooldownDisplay';
 import { dataService } from '@/services/dataService';
 import HelpDialog from '@/components/HelpDialog';
 import { Link } from 'react-router-dom';
@@ -22,7 +23,19 @@ const SECURITY_QUESTIONS = [
   "Would you share your login credentials with a close friend?"
 ];
 
+const RECOMMENDED_ANSWERS: ('yes' | 'no')[] = [
+  'no',
+  'yes',
+  'yes',
+  'no',
+  'yes',
+  'no',
+  'yes',
+  'no'
+];
+
 const QUESTION_DURATION_MS = 45000;
+const COOLDOWN_DURATION_MS = 20000;
 
 const Index = () => {
   const [currentQuestion, setCurrentQuestion] = useState(0);
@@ -33,6 +46,8 @@ const Index = () => {
   const [fps, setFps] = useState(30);
   const [detectedFaces, setDetectedFaces] = useState([]);
   const [timeRemaining, setTimeRemaining] = useState(QUESTION_DURATION_MS / 1000);
+  const [cooldownRemaining, setCooldownRemaining] = useState(COOLDOWN_DURATION_MS / 1000);
+  const [isCooldown, setIsCooldown] = useState(false);
   const [sessionStats, setSessionStats] = useState(dataService.getSessionStats());
   const [isHelpOpen, setIsHelpOpen] = useState(false);
   
@@ -49,41 +64,51 @@ const Index = () => {
     setVotes(savedVotes);
   }, []);
 
-  // Rotate questions every 45s
+  // Question/Cooldown cycle
   useEffect(() => {
-    const interval = setInterval(() => {
-      const nextQuestion = (currentQuestion + 1) % SECURITY_QUESTIONS.length;
-      setCurrentQuestion(nextQuestion);
-      dataService.setCurrentQuestion(nextQuestion);
-
-      const questionVotes = dataService.getVotesForQuestion(nextQuestion);
-      setVotes(questionVotes);
-
-      setSessionStats(dataService.getSessionStats());
-      
-      console.log(`Switched to question ${nextQuestion + 1}: "${SECURITY_QUESTIONS[nextQuestion]}"`);
-    }, 45000);
-
-    return () => clearInterval(interval);
-  }, [currentQuestion]);
-
-  // Countdown timer for current question
-  useEffect(() => {
+    if (isCooldown) return;
     const start = Date.now();
     const tick = () => {
       const elapsed = Date.now() - start;
       const remaining = Math.max(0, QUESTION_DURATION_MS - elapsed);
       setTimeRemaining(Math.ceil(remaining / 1000));
+      if (remaining <= 0) {
+        setIsCooldown(true);
+      }
     };
     tick();
     const t = setInterval(tick, 1000);
     return () => clearInterval(t);
-  }, [currentQuestion]);
+  }, [currentQuestion, isCooldown]);
+
+  // Cooldown timer
+  useEffect(() => {
+    if (!isCooldown) return;
+    const start = Date.now();
+    const tick = () => {
+      const elapsed = Date.now() - start;
+      const remaining = Math.max(0, COOLDOWN_DURATION_MS - elapsed);
+      setCooldownRemaining(Math.ceil(remaining / 1000));
+      if (remaining <= 0) {
+        const nextQuestion = (currentQuestion + 1) % SECURITY_QUESTIONS.length;
+        setCurrentQuestion(nextQuestion);
+        dataService.setCurrentQuestion(nextQuestion);
+        const questionVotes = dataService.getVotesForQuestion(nextQuestion);
+        setVotes(questionVotes);
+        setSessionStats(dataService.getSessionStats());
+        setIsCooldown(false);
+      }
+    };
+    tick();
+    const t = setInterval(tick, 1000);
+    return () => clearInterval(t);
+  }, [isCooldown, currentQuestion]);
 
   // -----------------------------------------
   // 1) Memoized Callback: handleGestureDetected
   // -----------------------------------------
   const handleGestureDetected = useCallback((gesture: 'yes' | 'no', faceId: number) => {
+    if (isCooldown) return;
     console.log(`Gesture detected: Face ${faceId} voted ${gesture} for question ${currentQuestion + 1}`);
     
     // Initialize vote tracking for this question if not exists
@@ -227,13 +252,20 @@ const Index = () => {
           </div>
         </div>
 
-        <QuestionDisplay
-          question={SECURITY_QUESTIONS[currentQuestion]}
-          questionIndex={currentQuestion + 1}
-          totalQuestions={SECURITY_QUESTIONS.length}
-          timeRemaining={timeRemaining}
-          questionDuration={QUESTION_DURATION_MS / 1000}
-        />
+        {isCooldown ? (
+          <CooldownDisplay
+            recommended={RECOMMENDED_ANSWERS[currentQuestion]}
+            remaining={cooldownRemaining}
+          />
+        ) : (
+          <QuestionDisplay
+            question={SECURITY_QUESTIONS[currentQuestion]}
+            questionIndex={currentQuestion + 1}
+            totalQuestions={SECURITY_QUESTIONS.length}
+            timeRemaining={timeRemaining}
+            questionDuration={QUESTION_DURATION_MS / 1000}
+          />
+        )}
 
         <div className="mt-6 grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Webcam + Controls */}


### PR DESCRIPTION
## Summary
- add CooldownDisplay component
- rotate questions only after a 45s period followed by a 20s cooldown
- ignore gestures while in cooldown
- surface recommended answers during cooldown
- tweak nod detection thresholds so YES votes register better

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e075f17c48320adc4f32687a52388