### PR TITLE
Add usernames overlay and cyber match popup

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -176,12 +176,9 @@ const Index = () => {
   }, []);
 
   const handleConflictPair = useCallback(() => {
-    console.log('Conflict pair detected - opening discussion');
-    toast('Matched with an opposite viewpoint! Join the discussion.');
-    if (!isDiscussionOpen) {
-      setIsDiscussionOpen(true);
-    }
-  }, [isDiscussionOpen]);
+    console.log('Conflict pair detected');
+    toast('It\'s a cyber match!');
+  }, []);
 
   // -----------------------------------------
   // Clear / Export data


### PR DESCRIPTION
## Summary
- map tracked faces to cool usernames and show them on the webcam overlay
- keep username list in sync when faces disappear
- trigger a toast notification instead of immediately opening chat when conflicting votes occur

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed4efc0a4832098b95d3d97893259