### PR TITLE
Integrate DeepSeek chat assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Nod & Know
 
 Nod & Know is an interactive security awareness demo. It uses your webcam to detect nodding for **yes** and shaking for **no** while you answer short security questions. Votes are stored in your browser and you can join an anonymous chat to discuss each question.
+Messages that begin with `@ai` will summon an automated assistant powered by DeepSeek to provide more information about the current topic.
 
 ## Getting Started
 
@@ -10,7 +11,8 @@ Nod & Know is an interactive security awareness demo. It uses your webcam to det
    ```
 2. Start the WebSocket server:
    ```sh
-   npm run server
+   # DEEPSEEK_API_KEY is optional but required for the @ai assistant
+   DEEPSEEK_API_KEY=your_key npm run server
    ```
    This starts a Socket.IO server on <http://localhost:3001>.
 

--- a/server.js
+++ b/server.js
@@ -2,6 +2,34 @@
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 
+// Simple wrapper to call DeepSeek's chat API
+async function callDeepSeek(prompt) {
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+  if (!apiKey) {
+    throw new Error('DEEPSEEK_API_KEY environment variable not set');
+  }
+
+  const res = await fetch('https://api.deepseek.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'deepseek-chat',
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`DeepSeek API error: ${text}`);
+  }
+
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content?.trim() || '';
+}
+
 const httpServer = createServer();
 
 const io = new Server(httpServer, {
@@ -12,14 +40,15 @@ const io = new Server(httpServer, {
 });
 
 io.on('connection', (socket) => {
-  socket.on('joinRoom', ({ roomId, username }) => {
+  socket.on('joinRoom', ({ roomId, username, topic }) => {
     socket.join(roomId);
     socket.data.roomId = roomId;
     socket.data.username = username;
+    socket.data.topic = topic;
     socket.to(roomId).emit('userJoined', username);
   });
 
-  socket.on('message', ({ roomId, text, userId, username }) => {
+  socket.on('message', async ({ roomId, text, userId, username }) => {
     const payload = {
       id: Date.now().toString(),
       text,
@@ -28,6 +57,24 @@ io.on('connection', (socket) => {
       username,
     };
     io.to(roomId).emit('message', payload);
+
+    if (text.trim().startsWith('@ai')) {
+      const prompt = text.replace(/^@ai\s*/, '') ||
+        `Tell me more about: ${socket.data.topic || ''}`;
+      try {
+        const reply = await callDeepSeek(prompt);
+        const aiPayload = {
+          id: Date.now().toString() + '_ai',
+          text: reply,
+          timestamp: new Date().toISOString(),
+          userId: 'deepseek',
+          username: 'AI Assistant',
+        };
+        io.to(roomId).emit('message', aiPayload);
+      } catch (err) {
+        console.error(err);
+      }
+    }
   });
 
   socket.on('leaveRoom', ({ roomId }) => {

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -103,7 +103,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
     });
 
     // Join room based on question
-    websocketService.joinRoom(roomId);
+    websocketService.joinRoom(roomId, question);
 
     return () => {
       websocketService.leaveRoom();

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -81,12 +81,13 @@ class WebSocketService {
     });
   }
 
-  joinRoom(roomId: string) {
+  joinRoom(roomId: string, topic?: string) {
     if (!this.socket) return;
     this.currentRoom = roomId;
     this.socket.emit('joinRoom', {
       roomId,
-      username: this.username
+      username: this.username,
+      topic,
     });
   }
 


### PR DESCRIPTION
## Summary
- allow messages beginning with `@ai` to trigger a DeepSeek API call
- wire question/topic data when joining a chat room
- document the new `DEEPSEEK_API_KEY` env variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686a4af2bb488320a4cfa0837912b3d4