### PR TITLE
Improve chat AI hint and DeepSeek integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nod & Know
 
 Nod & Know is an interactive security awareness demo. It uses your webcam to detect nodding for **yes** and shaking for **no** while you answer short security questions. Votes are stored in your browser and you can join an anonymous chat to discuss each question.
-Messages that begin with `@ai` will summon an automated assistant powered by DeepSeek to provide more information about the current topic.
+Messages that begin with `@ai` will summon an automated assistant powered by DeepSeek to provide more information about the current topic. Answers include a couple of suggested follow-up questions to keep the discussion going.
 
 ## Getting Started
 

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -58,7 +58,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
 
     const welcomeMessage: ChatMessage = {
       id: 'welcome',
-      text: isMobileQRMode 
+      text: isMobileQRMode
         ? `Welcome to the mobile discussion, ${currentUserName}! Share your security experiences and learn from others. All conversations are anonymous.`
         : `Welcome, ${currentUserName}! Share your security experiences and learn from others. All conversations are anonymous.`,
       timestamp: new Date(),
@@ -66,7 +66,15 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
       username: 'SecureMatch'
     };
 
-    setMessages([topicMessage, welcomeMessage]);
+    const aiHintMessage: ChatMessage = {
+      id: 'ai_hint',
+      text: 'Hint: start a message with @ai to ask our AI assistant.',
+      timestamp: new Date(),
+      userId: 'system',
+      username: 'SecureMatch'
+    };
+
+    setMessages([topicMessage, welcomeMessage, aiHintMessage]);
 
     // Connect to WebSocket
     websocketService.connect({
@@ -305,6 +313,13 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
                       }`}
                     >
                       <p className="whitespace-pre-wrap break-words">{message.text}</p>
+                      {message.followUp && message.followUp.length > 0 && (
+                        <ul className="mt-2 list-disc list-inside space-y-1 text-sm">
+                          {message.followUp.map((q, idx) => (
+                            <li key={idx}>{q}</li>
+                          ))}
+                        </ul>
+                      )}
                       <div className="text-xs opacity-70 mt-1">
                         {message.timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                       </div>
@@ -325,7 +340,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
                   value={newMessage}
                   onChange={(e) => setNewMessage(e.target.value)}
                   onKeyPress={handleKeyPress}
-                  placeholder="Enter your message"
+                  placeholder="Enter your message (use @ai for help)"
                   disabled={!isConnected}
                   className="bg-gray-700 border-gray-600 text-white placeholder-gray-400 rounded-lg px-3 md:px-4 py-2 md:py-3 text-sm md:text-base"
                   maxLength={500}

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -6,6 +6,7 @@ interface ChatMessage {
   timestamp: Date;
   userId: string;
   username: string;
+  followUp?: string[];
 }
 
 interface WebSocketServiceCallbacks {


### PR DESCRIPTION
## Summary
- add startup hint about using `@ai`
- explain `@ai` usage in message input placeholder
- pull DeepSeek API key from `DEEPSEEK_API_KEY` and maintain brief chat history for context
- show follow-up questions from DeepSeek in the chat

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686a574eea308320a461084f9e1981aa