### PR TITLE
Add DeepSeek explanations for questions

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -105,6 +105,21 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
     // Join room based on question
     websocketService.joinRoom(roomId, question);
 
+    // Fetch AI answer and add as message
+    fetch(`/ai-answer?q=${encodeURIComponent(question)}`)
+      .then(res => res.json())
+      .then(data => {
+        const aiMsg: ChatMessage = {
+          id: `ai_${Date.now()}`,
+          text: data.answer,
+          timestamp: new Date(),
+          userId: 'deepseek',
+          username: 'AI Assistant'
+        };
+        setMessages(prev => [...prev, aiMsg]);
+      })
+      .catch(err => console.error('Failed to fetch AI answer', err));
+
     return () => {
       websocketService.leaveRoom();
       websocketService.disconnect();

--- a/src/components/QuestionDisplay.tsx
+++ b/src/components/QuestionDisplay.tsx
@@ -8,6 +8,7 @@ interface QuestionDisplayProps {
   totalQuestions: number;
   timeRemaining: number;
   questionDuration: number;
+  aiAnswer?: string;
 }
 
 const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
@@ -16,6 +17,7 @@ const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
   totalQuestions,
   timeRemaining,
   questionDuration,
+  aiAnswer,
 }) => {
   return (
     <Card className="bg-black/60 border-gray-700 p-8 shadow-lg">
@@ -36,6 +38,12 @@ const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
           {question}
         </p>
       </div>
+
+      {aiAnswer && (
+        <div className="mb-6 text-sm text-purple-200 text-center whitespace-pre-wrap">
+          {aiAnswer}
+        </div>
+      )}
 
       <div className="flex justify-between items-center text-sm text-gray-400">
         <span>Next question in {timeRemaining}s</span>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -88,6 +88,7 @@ const Index = () => {
   const [qrTopic, setQrTopic] = useState<string | null>(null);
   const [localIP, setLocalIP] = useState<string>('');
   const [qrCodeUrl, setQrCodeUrl] = useState<string>('');
+  const [aiAnswer, setAiAnswer] = useState<string>('');
   
   // Track which face IDs have voted for which questions (persisted across question changes)
   const faceVotesRef = useRef<Record<number, Set<number>>>({});
@@ -143,6 +144,15 @@ const Index = () => {
       generateQRCode();
     }
   }, [currentQuestion, generateQRCode, qrRoomId]);
+
+  // Fetch AI answer when question changes
+  useEffect(() => {
+    setAiAnswer('');
+    fetch(`/ai-answer?q=${encodeURIComponent(SECURITY_QUESTIONS[currentQuestion])}`)
+      .then(res => res.json())
+      .then(data => setAiAnswer(data.answer))
+      .catch(err => console.error('Failed to fetch AI answer', err));
+  }, [currentQuestion]);
 
   // Question/Cooldown cycle
   useEffect(() => {
@@ -361,6 +371,7 @@ const Index = () => {
               totalQuestions={SECURITY_QUESTIONS.length}
               timeRemaining={timeRemaining}
               questionDuration={QUESTION_DURATION_MS / 1000}
+              aiAnswer={aiAnswer}
             />
           )}
 


### PR DESCRIPTION
## Summary
- add an HTTP endpoint `/ai-answer` in the websocket server to fetch concise DeepSeek answers
- display these answers below each question
- show the same answer at the start of every chat session

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bde8967588320bfb8f9a1063eea3c